### PR TITLE
`Patch:` sort results by time and enumerate ranks

### DIFF
--- a/src/app/content/events/components/event-view/event-view.component.ts
+++ b/src/app/content/events/components/event-view/event-view.component.ts
@@ -199,35 +199,33 @@ export class EventViewComponent implements OnInit, OnDestroy {
                                 // TODO: reassign ranks for all age groups, not working because of starters being not in the ranking:
                                 // https://bsv-sws.de/images/ergebnisdienst/bm2025/proto_wk002.pdf
                                 // Assign ranks
-                                // let currentRank = 1;
-                                // let lastTime: number | null = null;
-                                // let skippedRanks = 0;
-                                //
-                                // for (let i = 0; i < age.starts.length; i++) {
-                                //     const start = age.starts[i];
-                                //     const startImpl = new StartImpl(start);
-                                //
-                                //     if (startImpl.disqualification.reason || !startImpl.getResultMilliseconds()) {
-                                //         start.rank = 0;
-                                //         skippedRanks++;
-                                //         continue;
-                                //     }
-                                //
-                                //     const time = startImpl.getResultMilliseconds();
-                                //
-                                //     if (lastTime === null) {
-                                //         start.rank = currentRank;
-                                //     } else if (time === lastTime) {
-                                //         start.rank = currentRank;
-                                //         skippedRanks++;
-                                //     } else {
-                                //         currentRank += skippedRanks + 1;
-                                //         start.rank = currentRank;
-                                //         skippedRanks = 0;
-                                //     }
-                                //
-                                //     lastTime = time;
-                                // }
+                                let currentRank = 1;
+                                let lastTime: number | null = null;
+                                let skippedRanks = 0;
+
+                                for (const start of age.starts) {
+                                    const startImpl = new StartImpl(start);
+                                    if (startImpl.disqualification.reason || !startImpl.getResultMilliseconds()) {
+                                        start.rank = 0;
+                                        skippedRanks++;
+                                        continue;
+                                    }
+
+                                    const time = startImpl.getResultMilliseconds();
+
+                                    if (lastTime === null) {
+                                        start.rank = currentRank;
+                                    } else if (time === lastTime) {
+                                        start.rank = currentRank;
+                                        skippedRanks++;
+                                    } else {
+                                        currentRank += skippedRanks + 1;
+                                        start.rank = currentRank;
+                                        skippedRanks = 0;
+                                    }
+
+                                    lastTime = time;
+                                }
                             }
                             this.resultStarts.push(age)
                         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Age group rankings for race events are now properly calculated based on competitor results, with correct handling of finish times and special cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->