### PR TITLE
`Patch`: fix overlapping livetiming control text on small screens

### DIFF
--- a/src/app/content/live/components/livetiming/livetiming-controls/livetiming-controls.component.scss
+++ b/src/app/content/live/components/livetiming/livetiming-controls/livetiming-controls.component.scss
@@ -8,6 +8,10 @@ sr-icon-btn {
 }
 
 @media only screen and (max-width: 600px) {
+    :host {
+        height: 66px;
+    }
+
     .info-text {
         position: absolute;
         display: block;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Enhanced mobile responsiveness for live timing controls with optimized layout constraints on small screens (max-width: 600px).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->